### PR TITLE
fragment and activity names in navigation.xml corrected

### DIFF
--- a/app/src/main/java/com/makentoshe/androidgithubcitemplate/fragments/EditFragment.kt
+++ b/app/src/main/java/com/makentoshe/androidgithubcitemplate/fragments/EditFragment.kt
@@ -1,6 +1,5 @@
 package com.makentoshe.androidgithubcitemplate.fragments
 
-import EditFragmentDirections
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View

--- a/app/src/main/res/navigation/navigation.xml
+++ b/app/src/main/res/navigation/navigation.xml
@@ -7,7 +7,7 @@
 
     <fragment
         android:id="@+id/editFragment"
-        android:name="EditFragment"
+        android:name="com.makentoshe.androidgithubcitemplate.fragments.EditFragment"
         android:label="fragment_edit"
         tools:layout="@layout/fragment_edit" >
         <argument
@@ -30,12 +30,12 @@
         app:startDestination="@id/mainActivity">
         <activity
             android:id="@+id/mainActivity"
-            android:name="MainActivity"
+            android:name="com.makentoshe.androidgithubcitemplate.activity.MainActivity"
             android:label="MainActivity" />
     </navigation>
     <fragment
         android:id="@+id/mainFragmentDD"
-        android:name="MainFragmentDD"
+        android:name="com.makentoshe.androidgithubcitemplate.fragments.MainFragmentDD"
         android:label="fragment_main_d_d"
         tools:layout="@layout/fragment_main_d_d" >
         <action
@@ -47,7 +47,7 @@
     </fragment>
     <fragment
         android:id="@+id/startFragment"
-        android:name="StartFragment"
+        android:name="com.makentoshe.androidgithubcitemplate.fragments.StartFragment"
         android:label="fragment_start"
         tools:layout="@layout/fragment_start" >
         <action


### PR DESCRIPTION
В файле навигации тэг `android:name` требует полного пути до фрагмента или активности, на которую он указывает.